### PR TITLE
ライフ情報の設定

### DIFF
--- a/game.py
+++ b/game.py
@@ -37,4 +37,7 @@ class Cloud:
         self.immunity = False
         # the player cannot jump more than a specified amount of time
         self.immunity_count = 0
-        
+        # life
+        self.life = 4
+        # if the player is inflicted with damage, it cannnot be inflicted again for a certain amount of time
+        self.life_lost_time = 0


### PR DESCRIPTION
# ライフ情報の初期設定

初期ライフは4
ダメージ判定からライフへの判定秒数は0