### PR TITLE
ロープの当たり判定設定

### DIFF
--- a/game.py
+++ b/game.py
@@ -90,3 +90,10 @@ class Straight_Rope(Rope):
         elif(self.direction == "LEFT"):
             self.x -= self.velocity
         pygame.draw,line(screen, COLORS[3], [self.x, 0], [self.x, 480], 5)
+
+    # checks if the player and the rope collided
+    def judge(self, cloud):
+        if(self.x > (cloud.x) and self.x < (cloud + 20)):
+            return True
+        else:
+            return False

--- a/game.py
+++ b/game.py
@@ -93,7 +93,7 @@ class Straight_Rope(Rope):
 
     # checks if the player and the rope collided
     def judge(self, cloud):
-        if(self.x > (cloud.x) and self.x < (cloud + 20)):
+        if(self.x > (cloud.x) and self.x < (cloud.x + 20)):
             return True
         else:
             return False


### PR DESCRIPTION
# ロープの当たり判定定義

- キャラ(クラウド)に接触する範囲を設定</br>
キャラのサイズとロープの位置を指定して範囲内に入った時に当たり判定とする