### PR TITLE
ドットの当たり判定定義

### DIFF
--- a/game.py
+++ b/game.py
@@ -123,3 +123,10 @@ class Shooting_Star(Rope):
         self.x += self.tilt
         self.y += self.velocity
         pygame.draw.circle(screen, COLORS[self.color], [self.x self.y], 6)
+
+    # checks if the player and the dot collided
+    def judge(self, cloud):
+        if((self.y > (cloud.y) and self.y < (cloud.y + 20)) and (self.x > (cloud.x) and self.x < (cloud.x + 20)))
+            return True
+        else:
+            return False


### PR DESCRIPTION
# ドット(敵)の当たり判定定義

- 縦横がキャラの表示範囲と重なる時にドットの当たり判定をする